### PR TITLE
chore: remove unneeded experimental.module option

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,7 +5,6 @@ package proofwidgets where
   preferReleaseBuild := true
   buildArchive? := "ProofWidgets4.tar.gz"
   releaseRepo := "https://github.com/leanprover-community/ProofWidgets4"
-  leanOptions := #[⟨`experimental.module, true⟩]
 
 def widgetDir : FilePath := "widget"
 


### PR DESCRIPTION
The `experimental.module` option is no longer necessary with v4.27.0-rc1.