### PR TITLE
feat: allow `import ProofWidgets` from inside a `module`

### DIFF
--- a/ProofWidgets.lean
+++ b/ProofWidgets.lean
@@ -1,17 +1,19 @@
-import ProofWidgets.Compat
-import ProofWidgets.Component.Basic
-import ProofWidgets.Component.FilterDetails
-import ProofWidgets.Component.GraphDisplay
-import ProofWidgets.Component.HtmlDisplay
-import ProofWidgets.Component.InteractiveSvg
-import ProofWidgets.Component.MakeEditLink
-import ProofWidgets.Component.OfRpcMethod
-import ProofWidgets.Component.Panel.Basic
-import ProofWidgets.Component.Panel.GoalTypePanel
-import ProofWidgets.Component.Panel.SelectionPanel
-import ProofWidgets.Component.PenroseDiagram
-import ProofWidgets.Component.Recharts
-import ProofWidgets.Data.Html
-import ProofWidgets.Data.Svg
-import ProofWidgets.Presentation.Expr
-import ProofWidgets.Extra.CheckHighlight
+module
+
+public import ProofWidgets.Compat
+public import ProofWidgets.Component.Basic
+public import ProofWidgets.Component.FilterDetails
+public import ProofWidgets.Component.GraphDisplay
+public import ProofWidgets.Component.HtmlDisplay
+public import ProofWidgets.Component.InteractiveSvg
+public import ProofWidgets.Component.MakeEditLink
+public import ProofWidgets.Component.OfRpcMethod
+public import ProofWidgets.Component.Panel.Basic
+public import ProofWidgets.Component.Panel.GoalTypePanel
+public import ProofWidgets.Component.Panel.SelectionPanel
+public import ProofWidgets.Component.PenroseDiagram
+public import ProofWidgets.Component.Recharts
+public import ProofWidgets.Data.Html
+public import ProofWidgets.Data.Svg
+public import ProofWidgets.Presentation.Expr
+public import ProofWidgets.Extra.CheckHighlight


### PR DESCRIPTION
The file `ProofWidgets.lean` was not a `module` before. As a result, it was not possible to write `import ProofWidgets` in e.g. Mathlib. This PR fixes that.