### PR TITLE
chore: reduce imports

### DIFF
--- a/ProofWidgets/Cancellable.lean
+++ b/ProofWidgets/Cancellable.lean
@@ -1,10 +1,8 @@
 module
 
-public meta import Lean.Data.Json.FromToJson
 public meta import Lean.Server.Rpc.RequestHandling
-public meta import Std.Data.HashMap
-public meta import ProofWidgets.Compat
-public meta import ProofWidgets.Util
+public import ProofWidgets.Compat
+public import ProofWidgets.Util
 
 /-! # This file is DEPRECATED since v0.0.93 -/
 

--- a/ProofWidgets/Component/Basic.lean
+++ b/ProofWidgets/Component/Basic.lean
@@ -1,8 +1,7 @@
 module
 
-public meta import Lean.Widget.InteractiveCode
 public meta import Lean.Widget.UserWidget
-public meta import ProofWidgets.Compat
+public import ProofWidgets.Compat
 
 public meta section
 

--- a/ProofWidgets/Component/FilterDetails.lean
+++ b/ProofWidgets/Component/FilterDetails.lean
@@ -1,6 +1,6 @@
 module
 
-public meta import ProofWidgets.Data.Html
+public import ProofWidgets.Data.Html
 
 public meta section
 

--- a/ProofWidgets/Component/GraphDisplay.lean
+++ b/ProofWidgets/Component/GraphDisplay.lean
@@ -1,7 +1,6 @@
 module
 
-public meta import ProofWidgets.Component.Basic
-public meta import ProofWidgets.Data.Html
+public import ProofWidgets.Data.Html
 
 public meta section
 

--- a/ProofWidgets/Component/HtmlDisplay.lean
+++ b/ProofWidgets/Component/HtmlDisplay.lean
@@ -1,9 +1,6 @@
 module
 
-public meta import Lean.Server.Rpc.Basic
-public meta import Lean.Elab.Command
-
-public meta import ProofWidgets.Data.Html
+public import ProofWidgets.Data.Html
 
 public meta section
 

--- a/ProofWidgets/Component/InteractiveSvg.lean
+++ b/ProofWidgets/Component/InteractiveSvg.lean
@@ -1,6 +1,6 @@
 module
 
-public meta import ProofWidgets.Data.Svg
+public import ProofWidgets.Data.Svg
 
 public meta section
 

--- a/ProofWidgets/Component/MakeEditLink.lean
+++ b/ProofWidgets/Component/MakeEditLink.lean
@@ -1,7 +1,6 @@
 module
 
-public meta import Lean.Server.Utils
-public meta import ProofWidgets.Component.Basic
+public import ProofWidgets.Component.Basic
 
 public meta section
 

--- a/ProofWidgets/Component/OfRpcMethod.lean
+++ b/ProofWidgets/Component/OfRpcMethod.lean
@@ -1,9 +1,7 @@
 module
 
-public meta import Lean.Elab.ElabRules
-public meta import ProofWidgets.Component.Basic
-public meta import ProofWidgets.Data.Html
-public meta import ProofWidgets.Cancellable
+import ProofWidgets.Data.Html
+public import ProofWidgets.Cancellable
 
 public meta section
 

--- a/ProofWidgets/Component/Panel/Basic.lean
+++ b/ProofWidgets/Component/Panel/Basic.lean
@@ -1,9 +1,8 @@
 module
 
-public meta import ProofWidgets.Compat
-public meta import ProofWidgets.Component.Basic
-public meta import Lean.Elab.Tactic
-public meta import Lean.Widget.Commands
+public import ProofWidgets.Component.Basic
+public meta import Lean.Elab.Tactic.BuiltinTactic
+public import Lean.Widget.Commands
 
 public meta section
 

--- a/ProofWidgets/Component/Panel/GoalTypePanel.lean
+++ b/ProofWidgets/Component/Panel/GoalTypePanel.lean
@@ -1,6 +1,6 @@
 module
 
-public meta import ProofWidgets.Component.Panel.Basic
+public import ProofWidgets.Component.Panel.Basic
 
 public meta section
 

--- a/ProofWidgets/Component/Panel/SelectionPanel.lean
+++ b/ProofWidgets/Component/Panel/SelectionPanel.lean
@@ -1,8 +1,7 @@
 module
 
 public meta import Lean.Meta.ExprLens
-public meta import ProofWidgets.Component.Panel.Basic
-public meta import ProofWidgets.Presentation.Expr
+public import ProofWidgets.Component.Panel.Basic
 
 public meta section -- Needed for RPC calls in SelectionPanel
 

--- a/ProofWidgets/Component/PenroseDiagram.lean
+++ b/ProofWidgets/Component/PenroseDiagram.lean
@@ -1,8 +1,6 @@
 module
 
-public meta import ProofWidgets.Component.Basic
-public meta import ProofWidgets.Data.Html
-public meta import Std.Data.HashMap
+public import ProofWidgets.Data.Html
 
 public meta section
 

--- a/ProofWidgets/Component/Recharts.lean
+++ b/ProofWidgets/Component/Recharts.lean
@@ -1,6 +1,6 @@
 module
 
-public meta import ProofWidgets.Component.Basic
+public import ProofWidgets.Component.Basic
 
 public meta section
 

--- a/ProofWidgets/Data/Html.lean
+++ b/ProofWidgets/Data/Html.lean
@@ -5,13 +5,9 @@
  -/
 module
 
-public meta import Lean.Data.Json.FromToJson
-public meta import Lean.Parser
-public meta import Lean.PrettyPrinter.Delaborator.Basic
-public meta import Lean.Server.Rpc.Basic
 
-public meta import ProofWidgets.Component.Basic
-public meta import ProofWidgets.Util
+public import ProofWidgets.Component.Basic
+public import ProofWidgets.Util
 
 public meta section
 

--- a/ProofWidgets/Data/Svg.lean
+++ b/ProofWidgets/Data/Svg.lean
@@ -1,7 +1,6 @@
 module
 
-public meta import ProofWidgets.Data.Html
-public meta import Std.Data.HashMap
+public import ProofWidgets.Data.Html
 
 public meta section
 

--- a/ProofWidgets/Demos/ExprPresentation.lean
+++ b/ProofWidgets/Demos/ExprPresentation.lean
@@ -1,7 +1,8 @@
 module
 
-public meta import ProofWidgets.Component.Panel.SelectionPanel
-public meta import ProofWidgets.Component.Panel.GoalTypePanel
+public import ProofWidgets.Component.Panel.SelectionPanel
+public import ProofWidgets.Component.Panel.GoalTypePanel
+public import ProofWidgets.Presentation.Expr
 
 public meta section
 

--- a/ProofWidgets/Extra/CheckHighlight.lean
+++ b/ProofWidgets/Extra/CheckHighlight.lean
@@ -1,8 +1,6 @@
 module
 
-public meta import Lean.Meta.Basic
-public meta import Lean.Elab.Command
-public meta import ProofWidgets.Component.HtmlDisplay
+public import ProofWidgets.Component.HtmlDisplay
 
 public meta section
 

--- a/ProofWidgets/Presentation/Expr.lean
+++ b/ProofWidgets/Presentation/Expr.lean
@@ -1,6 +1,6 @@
 module
 
-public meta import ProofWidgets.Data.Html
+public import ProofWidgets.Data.Html
 
 public meta section
 


### PR DESCRIPTION
This PR reduces imports, with the help of `lake shake`. In particular, there was an unnecessarily large import of `Lean.Elab.Tactic` that this PR removes.